### PR TITLE
Support entering a MQTT client identifier from the command line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Flags:
 --help-long and --help-man).
   --web.listen-address=":9337"  Address on which to expose metrics and web
 interface.
-  --mqtt.client-id=""              MQTT client identifier (limit to 23 chars)
+  --mqtt.client-id=""           MQTT client identifier (limit to 23 chars)
   --web.telemetry-path="/metrics"
                                 Path under which to expose metrics.
   --mqtt.broker-address="tcp://localhost:1883"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Flags:
 --help-long and --help-man).
   --web.listen-address=":9337"  Address on which to expose metrics and web
 interface.
+  --mqtt.client-id=""              MQTT client identifier (limit to 23 chars)
   --web.telemetry-path="/metrics"
                                 Path under which to expose metrics.
   --mqtt.broker-address="tcp://localhost:1883"

--- a/exporter.go
+++ b/exporter.go
@@ -27,6 +27,11 @@ func newMQTTExporter() *mqttExporter {
 	options := mqtt.NewClientOptions()
 	log.Infof("Connecting to %v", *brokerAddress)
 	options.AddBroker(*brokerAddress)
+
+	if (*clientID != "") {
+	    options.SetClientID(*clientID)
+	}
+
 	m := mqtt.NewClient(options)
 	if token := m.Connect(); token.Wait() && token.Error() != nil {
 		log.Fatal(token.Error())

--- a/main.go
+++ b/main.go
@@ -10,11 +10,12 @@ import (
 )
 
 var (
-	listenAddress = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9337").String()
-	metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-	brokerAddress = kingpin.Flag("mqtt.broker-address", "Address of the MQTT broker.").Default("tcp://localhost:1883").String()
+	listenAddress = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface").Default(":9337").String()
+	metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics").Default("/metrics").String()
+	brokerAddress = kingpin.Flag("mqtt.broker-address", "Address of the MQTT broker").Default("tcp://localhost:1883").String()
 	topic         = kingpin.Flag("mqtt.topic", "MQTT topic to subscribe to").Default("prometheus/#").String()
 	prefix        = kingpin.Flag("mqtt.prefix", "MQTT topic prefix to remove when creating metrics").Default("prometheus").String()
+	clientID      = kingpin.Flag("mqtt.client-id", "MQTT client identifier (limit to 23 characters)").Default("").String()
 	progname      = "mqttgateway"
 )
 


### PR DESCRIPTION
Working to integrate https://inductiveautomation.com/ MQTT solution with Prometheus.   There have been 3 issues during this integration.

1) Need to specify a client identifier to connect to MQTT
2) Support for SparkPlug payload (which we are working on now)
3) Support for auth

This PR is for #1.