### PR TITLE
Add support for setting the username and password on connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,25 @@ A project that subscribes to MQTT queues and published prometheus metrics.
 usage: mqttgateway [<flags>]
 
 Flags:
-  --help                        Show context-sensitive help (also try
---help-long and --help-man).
-  --web.listen-address=":9337"  Address on which to expose metrics and web
-interface.
+  --help                        Show context-sensitive help (also try --help-long and --help-man).
+  --web.listen-address=":9337"  Address on which to expose metrics and web interface.
   --web.telemetry-path="/metrics"
                                 Path under which to expose metrics.
   --mqtt.broker-address="tcp://localhost:1883"
                                 Address of the MQTT broker.
-  --mqtt.topic="prometheus/#"   MQTT topic to subscribe to
-  --mqtt.prefix="prometheus"    MQTT topic prefix to remove when creating
-metrics
-  --log.level="info"            Only log messages with the given severity or
-above. Valid levels: [debug, info, warn, error, fatal]
-  --log.format="logger:stderr"  Set the log target and format. Example:
-"logger:syslog?appname=bob&local=7" or "logger:stdout?json=true"
+                                The default is taken from $MQTT_BROKER_ADDRESS if it is set.
+  --mqtt.topic="prometheus/#"   MQTT topic to subscribe to.
+                                The default is taken from $MQTT_TOPIC if it is set.
+  --mqtt.prefix="prometheus"    MQTT topic prefix to remove when creating metrics.
+                                The default is taken from $MQTT_PREFIX if it is set.
+  --mqtt.username=""            MQTT username.
+                                The default is taken from $MQTT_USERNME if it is set.
+  --mqtt.password=""            MQTT password.
+                                The default is taken from $MQTT_PASSWORD if it is set.
+  --mqtt.clientid=""            MQTT client ID.
+                                The default is taken from $MQTT_CLIENT_ID if it is set.
+  --log.level="info"            Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]
+  --log.format="logger:stderr"  Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true"
 ```
 
 ## Installation

--- a/exporter.go
+++ b/exporter.go
@@ -27,6 +27,16 @@ func newMQTTExporter() *mqttExporter {
 	options := mqtt.NewClientOptions()
 	log.Infof("Connecting to %v", *brokerAddress)
 	options.AddBroker(*brokerAddress)
+	options.SetAutoReconnect(true)
+	if *username != "" {
+		options.SetUsername(*username)
+	}
+	if *password != "" {
+		options.SetPassword(*password)
+	}
+	if *clientID != "" {
+		options.SetClientID(*clientID)
+	}
 	m := mqtt.NewClient(options)
 	if token := m.Connect(); token.Wait() && token.Error() != nil {
 		log.Fatal(token.Error())

--- a/exporter.go
+++ b/exporter.go
@@ -27,7 +27,6 @@ func newMQTTExporter() *mqttExporter {
 	options := mqtt.NewClientOptions()
 	log.Infof("Connecting to %v", *brokerAddress)
 	options.AddBroker(*brokerAddress)
-	options.SetAutoReconnect(true)
 	if *username != "" {
 		options.SetUsername(*username)
 	}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -15,6 +16,9 @@ var (
 	brokerAddress = kingpin.Flag("mqtt.broker-address", "Address of the MQTT broker.").Default("tcp://localhost:1883").String()
 	topic         = kingpin.Flag("mqtt.topic", "MQTT topic to subscribe to").Default("prometheus/#").String()
 	prefix        = kingpin.Flag("mqtt.prefix", "MQTT topic prefix to remove when creating metrics").Default("prometheus").String()
+	username      = kingpin.Flag("mqtt.username", "MQTT username").Default(os.Getenv("MQTT_USERNAME")).String()
+	password      = kingpin.Flag("mqtt.password", "MQTT password").Default(os.Getenv("MQTT_PASSWORD")).String()
+	clientID      = kingpin.Flag("mqtt.clientid", "MQTT client ID").Default(os.Getenv("MQTT_CLIENT_ID")).String()
 	progname      = "mqttgateway"
 )
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"net/http"
-	"os"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -13,12 +12,12 @@ import (
 var (
 	listenAddress = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9337").String()
 	metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-	brokerAddress = kingpin.Flag("mqtt.broker-address", "Address of the MQTT broker.").Default("tcp://localhost:1883").String()
-	topic         = kingpin.Flag("mqtt.topic", "MQTT topic to subscribe to").Default("prometheus/#").String()
-	prefix        = kingpin.Flag("mqtt.prefix", "MQTT topic prefix to remove when creating metrics").Default("prometheus").String()
-	username      = kingpin.Flag("mqtt.username", "MQTT username").Default(os.Getenv("MQTT_USERNAME")).String()
-	password      = kingpin.Flag("mqtt.password", "MQTT password").Default(os.Getenv("MQTT_PASSWORD")).String()
-	clientID      = kingpin.Flag("mqtt.clientid", "MQTT client ID").Default(os.Getenv("MQTT_CLIENT_ID")).String()
+	brokerAddress = kingpin.Flag("mqtt.broker-address", "Address of the MQTT broker.").Envar("MQTT_BROKER_ADDRESS").Default("tcp://localhost:1883").String()
+	topic         = kingpin.Flag("mqtt.topic", "MQTT topic to subscribe to").Envar("MQTT_TOPIC").Default("prometheus/#").String()
+	prefix        = kingpin.Flag("mqtt.prefix", "MQTT topic prefix to remove when creating metrics").Envar("MQTT_PREFIX").Default("prometheus").String()
+	username      = kingpin.Flag("mqtt.username", "MQTT username").Envar("MQTT_USERNAME").String()
+	password      = kingpin.Flag("mqtt.password", "MQTT password").Envar("MQTT_PASSWORD").String()
+	clientID      = kingpin.Flag("mqtt.clientid", "MQTT client ID").Envar("MQTT_CLIENT_ID").String()
 	progname      = "mqttgateway"
 )
 


### PR DESCRIPTION
My MQTT broker requires authentication. This adds support for that.

Because I deploy applications in containers, environment variables are often the way to pass in secrets like passwords, so this also defaults to taking the username and password from MQTT_USERNAME and MQTT_PASSWORD environment variables.